### PR TITLE
TASK: Flow 6.0+ support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This package provides simple brute-force prevention (account locking) for Neos/F
 
 A notification email can be send to an administrator when an account has been locked.
 
-Compatible with Neos 3.x + 4.x / Flow 4.x + 5.x
+Compatible with Neos 3.x or later / Flow 4.x or later (tested until 7.3)
 
 Be aware that there are ways to circumvent this protection and it can be misused,
 see [Blocking Brute Force Attacks](https://www.owasp.org/index.php/Blocking_Brute_Force_Attacks) for more information.

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"require": {
-		"neos/flow": ">4.0",
+		"neos/flow": ">=6.0",
 		"neos/swiftmailer": ">6.0"
 	},
 	"autoload": {


### PR DESCRIPTION
The code for getting data of the request changed with Flow 6.0 to be PSR-Compliant. 

This PR changes the code so this package can used with newer versions of Neos / Flow (tested up to version 7.3, but should also work with 8.x).